### PR TITLE
Allow RPC methods with imported input types

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -52,7 +52,7 @@ type Plugin interface {
 	Generate(file *FileDescriptor)
 	// GenerateImports produces the import declarations for this file.
 	// It is called after Generate.
-	GenerateImports(file *FileDescriptor)
+	GenerateImports(file *FileDescriptor, imports []*FileDescriptor)
 }
 
 var plugins []Plugin
@@ -941,7 +941,7 @@ func (g *Generator) generateImports() {
 	g.P()
 	// TODO: may need to worry about uniqueness across plugins
 	for _, p := range plugins {
-		p.GenerateImports(g.file)
+		p.GenerateImports(g.file, g.allFiles)
 		g.P()
 	}
 	g.P("// Reference imports to suppress errors if they are not otherwise used.")


### PR DESCRIPTION
Re: https://github.com/fiorix/protoc-gen-cobra/issues/2

The input type is assigned in the handler using the local type name.
This works fine if the type is part of the same package, but throws a
name error if the type was imported.

This makes two changes. The first is to check the the package of input
types to see if it's the same as the generated file's package (ie local)
and prefixes the type name if appropriate.

The second is to add import statements for any input types. This
requires a change to the `Plugin` interface, as `GenerateImports` has no
knowledge of the file's dependencies. This adds a second argument to
that method and adds import statements for any input types from exported
packages.